### PR TITLE
fix wob/pamixer mute toggle

### DIFF
--- a/.config/sway/config
+++ b/.config/sway/config
@@ -17,9 +17,11 @@ floating_modifier $mod
 default_border pixel 4
 
 # volume controls
-bindsym XF86AudioRaiseVolume exec pamixer -ui 2 && pamixer --get-volume > $WOBSOCK
-bindsym XF86AudioLowerVolume exec pamixer -ud 2 && pamixer --get-volume > $WOBSOCK
-bindsym XF86AudioMute exec pamixer --toggle-mute && ( pamixer --get-mute && echo 0 > $WOBSOCK ) || pamixer --get-volume > $WOBSOCK
+bindsym XF86AudioRaiseVolume exec pamixer -ui 2 --get-volume > $WOBSOCK
+bindsym XF86AudioLowerVolume exec pamixer -ud 2 --get-volume > $WOBSOCK
+bindsym XF86AudioMute exec pamixer --toggle-mute && ( $(pamixer --get-mute) && echo 0 || pamixer --get-volume) > $WOBSOCK
+# alternative:
+# bindsym XF86AudioMute exec pamixer --toggle-mute --get-volume-human | sed 's,muted,0,; s,%,,' > $WOBSOCK
 
 # ddcutil
 bindsym $mod+n exec doas /usr/bin/ddcutil --noverify --less-sleep --sleep-multiplier .1 setvcp 10 - 5


### PR DESCRIPTION
My version of pamixer doesn't indicate muted status with exit codes, so your mute toggle wouldn't work for me, I've written 2 possible ways to fix this (personally I prefer the sed version, as it's clearer and cleaner than subshells)

Also removed unneccessary invocations of pamixer when changing volume :)

Hope this is useful! I was just cleaning up some things as I start using wob.